### PR TITLE
feature(xcmd): add the conf commands

### DIFF
--- a/xcmd/complete.py
+++ b/xcmd/complete.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+
+"""
+Parameter completion
+"""
+
+from functools import partial
+import shlex
+
+
+def complete(completers, cmd_param_text, full_cmd, *rest):
+    """
+    Given:
+
+    cmd → completers[0]()
+    cmd <incomplete-param-1> → completers[0]()
+    cmd <param1> → completers[1]()
+    cmd <param1> <param2> [trailing space] → completers[2]()
+    """
+
+    assert len(completers) > 0
+
+    pcount = len(shlex.split(full_cmd)) - 1
+
+    if pcount == 0:
+        pindex = 0
+    else:
+        pindex = pcount - 1
+
+        if full_cmd.endswith(' '):  # done with the current param?
+            pindex += 1
+
+        if pindex >= len(completers):
+            return []
+
+    return completers[pindex](cmd_param_text, full_cmd, *rest)
+
+
+def complete_values(values, cmd_param_text, full_cmd, *rest):
+    if full_cmd.endswith(' '):
+        return values
+
+    pieces = shlex.split(full_cmd)
+    param = pieces[-1] if len(pieces) > 1 else cmd_param_text
+    offs = len(param) - len(cmd_param_text)
+
+    return [val[offs:] for val in values if val.startswith(param)]
+
+
+complete_boolean = partial(complete_values, ['true', 'false'])
+
+
+def complete_labeled_boolean(label):
+    return partial(
+        complete_values,
+        ['%s=true' % label, '%s=false' % label, 'true', 'false']
+    )

--- a/xcmd/tests/test_complete.py
+++ b/xcmd/tests/test_complete.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+""" parameters parsing & handling test cases """
+
+from functools import partial
+
+import unittest
+
+from xcmd.complete import (
+    complete,
+    complete_boolean,
+    complete_labeled_boolean,
+    complete_values
+)
+
+
+class UtilTestCase(unittest.TestCase):
+    """ util tests cases """
+
+    @classmethod
+    def setUpClass(cls):
+        pass
+
+    def setUp(self):
+        pass
+
+    def test_complete(self):
+        completers = [partial(complete_values, ['/foo'])]
+        results = complete(completers, '/fo', 'ls /fo')
+        self.assertEquals(results, ['/foo'])
+
+    def test_complete_boolean(self):
+        completers = [complete_boolean]
+        results = complete(completers, 'tru', 'debug tru')
+        self.assertEquals(results, ['true'])
+
+    def test_complete_labeled_boolean(self):
+        completers = [complete_labeled_boolean('verbose')]
+        results = complete(completers, 'verbose=f', 'debug verbose=f')
+        self.assertEquals(results, ['verbose=false'])


### PR DESCRIPTION
These series of commands enable shell implementations to persist
key/value (i.e.: for configuration management).